### PR TITLE
Refactor proxy server implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,13 @@
   "author": "",
   "license": "ISC",
   "packageManager": "pnpm@10.6.4",
-  "devDependencies": {
-    "@types/node": "^22.15.2"
-  },
   "dependencies": {
     "proxy-chain": "^2.5.8",
-    "tsx": "^4.19.3",
+    "tsx": "^4.19.3"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.1",
+    "@types/node": "^22.15.2",
     "typescript": "^5.8.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,13 +14,16 @@ importers:
       tsx:
         specifier: ^4.19.3
         version: 4.19.3
-      typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
     devDependencies:
+      '@types/express':
+        specifier: ^5.0.1
+        version: 5.0.1
       '@types/node':
         specifier: ^22.15.2
         version: 22.15.2
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
 
 packages:
 
@@ -174,8 +177,38 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@types/body-parser@1.19.5':
+    resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/express-serve-static-core@5.0.6':
+    resolution: {integrity: sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==}
+
+  '@types/express@5.0.1':
+    resolution: {integrity: sha512-UZUw8vjpWFXuDnjFTh7/5c2TWDlQqeXHi6hcN7F2XSVT5P+WmUnnbFS3KA6Jnc6IsEqI2qCVu2bK0R0J4A8ZQQ==}
+
+  '@types/http-errors@2.0.4':
+    resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
+
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
   '@types/node@22.15.2':
     resolution: {integrity: sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A==}
+
+  '@types/qs@6.9.18':
+    resolution: {integrity: sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@0.17.4':
+    resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
+
+  '@types/serve-static@1.15.7':
+    resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
 
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
@@ -328,9 +361,50 @@ snapshots:
   '@esbuild/win32-x64@0.25.3':
     optional: true
 
+  '@types/body-parser@1.19.5':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 22.15.2
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.15.2
+
+  '@types/express-serve-static-core@5.0.6':
+    dependencies:
+      '@types/node': 22.15.2
+      '@types/qs': 6.9.18
+      '@types/range-parser': 1.2.7
+      '@types/send': 0.17.4
+
+  '@types/express@5.0.1':
+    dependencies:
+      '@types/body-parser': 1.19.5
+      '@types/express-serve-static-core': 5.0.6
+      '@types/serve-static': 1.15.7
+
+  '@types/http-errors@2.0.4': {}
+
+  '@types/mime@1.3.5': {}
+
   '@types/node@22.15.2':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/qs@6.9.18': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@0.17.4':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 22.15.2
+
+  '@types/serve-static@1.15.7':
+    dependencies:
+      '@types/http-errors': 2.0.4
+      '@types/node': 22.15.2
+      '@types/send': 0.17.4
 
   agent-base@7.1.3: {}
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,0 +1,4 @@
+export const config = {
+  port: Number(process.env.PORT) || 8888,
+  verbose: process.env.VERBOSE === 'true',
+};

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,0 +1,4 @@
+export const logger = {
+  info: (message: string) => console.log(`[INFO] ${message}`),
+  error: (message: string) => console.error(`[ERROR] ${message}`),
+};

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -1,0 +1,70 @@
+import { PrepareRequestFunctionOpts, Server } from 'proxy-chain';
+import { config } from '../config/config';
+import { logger } from './logger';
+
+const allowedHosts = [
+  'discord.com',
+  'youtube.com',
+  'googlevideo.com',
+];
+
+const getHostFromRawHeaders = (rawHeaders: string[] = []): string | null => {
+  for (let i = 0; i < rawHeaders.length; i += 2) {
+    if (rawHeaders[i].toLowerCase() === 'host') {
+      return rawHeaders[i + 1];
+    }
+  }
+  return null;
+};
+
+const isHostAllowed = (host: string) => {
+  return allowedHosts.some(allowed => host.includes(allowed));
+};
+
+export const startServer = async () => {
+  const server = new Server({
+    port: config.port,
+    verbose: config.verbose,
+
+    prepareRequestFunction: ({ request }: PrepareRequestFunctionOpts) => {
+      try {
+        const rawHeaders = request.rawHeaders;
+        const host = getHostFromRawHeaders(rawHeaders);
+
+        if (!host) {
+          logger.error(`Host header not found in the request headers.`);
+          return {
+            failMsg: 'Host header is missing in the request.',
+          };
+        }
+
+        logger.info(`Attempting to connect to host: ${host}`);
+
+        if (!isHostAllowed(host)) {
+          logger.error(`Connection blocked: Host "${host}" is not in the allowed list.`);
+          return {
+            failMsg: `Connection to "${host}" is not permitted.`,
+          };
+        }
+
+        return {};
+      } catch (err) {
+        logger.error(`Error while processing the request: ${(err as Error).message}`);
+        return {
+          failMsg: 'Internal error while processing the request.',
+        };
+      }
+    },
+  });
+
+  server.listen(() => {
+    logger.info(`Proxy server is running on port ${config.port}`);
+  });
+
+  server.on('requestFailed', (context) => {
+    if (context.request && context.request.url) {
+      logger.error(`Request failed for URL: ${context.request.url}`);
+    }
+  });
+
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,31 +1,3 @@
-import os from 'os';
-import { Server } from 'proxy-chain';
+import { startServer } from './core/server';
 
-const PROXY_PORT = 8888;
-
-function getLocalIP(): string | undefined {
-  const interfaces = os.networkInterfaces();
-  for (const iface of Object.values(interfaces)) {
-    if (!iface) continue;
-    for (const addr of iface) {
-      if (addr.family === 'IPv4' && !addr.internal) {
-        return addr.address;
-      }
-    }
-  }
-  return undefined;
-}
-
-const proxyServer = new Server({
-  port: PROXY_PORT,
-  prepareRequestFunction: ({ request }) => {
-    console.log(`[Proxy] ${new Date().toISOString()} - ${request.method} ${request.url}`);
-    return {};
-  },
-});
-
-proxyServer.listen().then(() => {
-  const localIp = getLocalIP();
-  console.log(`🚀 Proxy is listening on ${PROXY_PORT}`);
-  console.log(`🌐 Local access: http://${localIp}:${PROXY_PORT}`);
-});
+startServer();


### PR DESCRIPTION
- Removed the old proxy server setup in index.ts and replaced it with a call to startServer from core/server.ts.
- Introduced a new configuration file (config.ts) to manage server settings such as port and verbosity.
- Added a logger utility (logger.ts) for consistent logging of information and errors.
- Implemented the startServer function in server.ts, which sets up the proxy server with request handling and host validation.
- Added host validation to allow only specific hosts (discord.com, youtube.com, googlevideo.com) for proxy requests.