### PR TITLE
Feat add configurable logging options and improve logger setup

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,4 +1,6 @@
 export const config = {
   port: Number(process.env.PORT) || 8888,
   verbose: process.env.VERBOSE === 'true',
+  enableLogs: process.env.ENABLE_LOGS !== 'false',
+  enableErrorLogs: process.env.ENABLE_ERROR_LOGS !== 'false',
 };


### PR DESCRIPTION
This pull request introduces configurable logging behavior, allowing for more granular control over log outputs based on environment variables. Key changes include updates to the configuration file to support new logging options and modifications to the logger setup to conditionally enable or disable logging based on these configurations.

### Configuration Enhancements:

* [`src/config/config.ts`](diffhunk://#diff-615dacd7000fa06d7afef0f22b7b6d9267c6219fbfc9fa0315e51a5f5d963755R4-R5): Added two new configuration options, `enableLogs` and `enableErrorLogs`, to control whether general logs or only error logs are enabled. These options are derived from environment variables.

### Logger Updates:

* [`src/core/logger.ts`](diffhunk://#diff-b26e2d2c63ca623f55f84e869194f983f9dbb81fd0703cf38e5f11edc091f5c3R4): Imported the updated `config` object to access the new logging configurations.
* [`src/core/logger.ts`](diffhunk://#diff-b26e2d2c63ca623f55f84e869194f983f9dbb81fd0703cf38e5f11edc091f5c3R16-R33): Refactored the logger setup to dynamically configure transports based on the `enableLogs` and `enableErrorLogs` settings. The `allTransports` array now conditionally includes console and file transports for general or error-level logging.
* [`src/core/logger.ts`](diffhunk://#diff-b26e2d2c63ca623f55f84e869194f983f9dbb81fd0703cf38e5f11edc091f5c3R16-R33): Adjusted the logger's default level to `info`, `error`, or `silent`, depending on the configuration.