### PR TITLE
Docs/initial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+<h1 align="center"> 🧭 HTTP Proxy Server </h1>
+
+A robust and configurable HTTP proxy server developed in TypeScript, featuring authentication, host access control, and logging. Ideal for scenarios such as Discord bots, data scraping, and traffic control.
+
+## 🚀 Features
+
+- 🔐 Basic authentication via `.env`
+- 🌐 Host access control
+- 📄 Logging with Winston
+- ⚙️ Configuration via environment variables
+- 🧪 Modular and extensible structure
+
+## 📦 Installation
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/HCDevWorks/http-proxy.git
+   cd http-proxy
+   ```
+
+2. Install the dependencies:
+
+   ```bash
+   pnpm install
+   ```
+
+3. Configure the `.env` file:
+
+   ```env
+   PORT=8888
+   ENABLE_LOGS=true
+   ENABLE_ERROR_LOGS=false
+   PROXY_USERNAME=your_username
+   PROXY_PASSWORD=your_password
+   ```
+
+## 🛠️ Usage
+
+Start the proxy server with:
+
+```bash
+pnpm build # build the server
+
+and
+
+pnpm start # start the server
+```
+
+The server will listen on the port defined in `PORT` (default: 8888).
+
+## 📁 Project Structure
+
+```
+http-proxy/
+├── src/
+│   ├── config/
+│   │   └── config.ts       # Loads environment variables
+│   ├── logger/
+│   │   └── logger.ts       # Winston logger configuration
+│   └── server/
+│       └── server.ts       # Main proxy server logic
+├── .env                    # Environment variables
+├── package.json
+├── pnpm-lock.yaml
+├── tsconfig.json
+└── docs/
+    └── pt-br/
+        └── README.md       # Documentation in Brazilian Portuguese
+```
+
+## 📚 Documentation in Portuguese
+
+The complete documentation in Brazilian Portuguese is available at [`/docs/pt-br/README.md`](docs/pt-br/README.md).
+
+## 🤝 Contributing
+
+Contributions are welcome! Feel free to open issues or pull requests.
+
+## 📄 License
+
+This project is licensed under the MIT License.

--- a/docs/pt-br/README.md
+++ b/docs/pt-br/README.md
@@ -1,0 +1,82 @@
+<h1 align="center"> 🧭 HTTP Proxy Server </h1>
+
+Um servidor proxy HTTP robusto e configurável, desenvolvido em TypeScript, com suporte a autenticação, controle de acesso por host e registro de logs. Ideal para cenários como bots do Discord, raspagem de dados e controle de tráfego.
+
+## 🚀 Recursos
+
+- 🔐 Autenticação básica via `.env`
+- 🌐 Controle de acesso por host
+- 📄 Registro de logs com Winston
+- ⚙️ Configuração via variáveis de ambiente
+- 🧪 Estrutura modular e extensível
+
+## 📦 Instalação
+
+1. Clone o repositório:
+
+   ```bash
+   git clone https://github.com/HCDevWorks/http-proxy.git
+   cd http-proxy
+   ```
+
+2. Instale as dependências:
+
+```bash
+pnpm build # compila o servidor
+
+and
+
+pnpm start # inicia o servidor
+```
+
+3. Configure o arquivo `.env`:
+
+   ```env
+   PORT=8888
+   ENABLE_LOGS=true
+   ENABLE_ERROR_LOGS=false
+   PROXY_USERNAME=seu_usuario
+   PROXY_PASSWORD=sua_senha
+   ```
+
+## 🛠️ Uso
+
+Inicie o servidor proxy com:
+
+```bash
+pnpm start
+```
+
+O servidor estará escutando na porta definida em `PORT` (padrão: 8888).
+
+## 📁 Estrutura do Projeto
+
+```
+http-proxy/
+├── src/
+│   ├── config/
+│   │   └── config.ts       # Carrega as variáveis de ambiente
+│   ├── logger/
+│   │   └── logger.ts       # Configuração do Winston
+│   └── server/
+│       └── server.ts       # Lógica principal do servidor proxy
+├── .env                    # Variáveis de ambiente
+├── package.json
+├── pnpm-lock.yaml
+├── tsconfig.json
+└── docs/
+    └── pt-br/
+        └── README.md       # Documentação em português brasileiro
+```
+
+## 📚 Documentação em Português
+
+A documentação completa em português brasileiro está disponível em [`/docs/pt-br/README.md`](docs/pt-br/README.md).
+
+## 🤝 Contribuição
+
+Contribuições são bem-vindas! Sinta-se à vontade para abrir issues ou pull requests.
+
+## 📄 Licença
+
+Este projeto está licenciado sob a Licença MIT.


### PR DESCRIPTION
This pull request adds comprehensive documentation for the HTTP Proxy Server project, including an English `README.md` and a Brazilian Portuguese version in `docs/pt-br/README.md`. The documentation outlines the project's features, installation steps, usage instructions, project structure, and contribution guidelines.

### Documentation Updates:

* Added an English `README.md` file with detailed project information, including features, installation steps, usage instructions, a project structure overview, and contribution and license details.
* Added a Brazilian Portuguese `README.md` in `docs/pt-br/README.md` with equivalent content to the English version, tailored for Portuguese-speaking users.