### PR TITLE
Docs/improving

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 DaniHRE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
   <img src="./docs/static/demo.gif">
 </p>
 
+<p align="center">
+   English
+   | 
+  <a href="./docs/pt-br/README.md">Português</a>
+</p>
+
 A robust and configurable HTTP proxy server developed in TypeScript, featuring authentication, host access control, and logging. Ideal for scenarios such as Discord bots, data scraping, and traffic control.
 
 ## 🚀 Features
@@ -38,6 +44,19 @@ A robust and configurable HTTP proxy server developed in TypeScript, featuring a
    PROXY_USERNAME=your_username
    PROXY_PASSWORD=your_password
    ```
+## 🛠️ Usage
+
+Start the proxy server with:
+
+```bash
+pnpm build # build the server
+
+and
+
+pnpm start # start the server
+```
+
+The server will listen on the port defined in `PORT` (default: 8888).
 
 ## 🛡️ Allowed Hosts
 
@@ -55,20 +74,6 @@ const allowedHosts = [
 Only requests targeting hosts that include one of these strings will be allowed through the proxy.  
 To allow more domains, simply add them to the array.  
 If a client tries to access a host not listed, the connection will be blocked and logged.
-
-## 🛠️ Usage
-
-Start the proxy server with:
-
-```bash
-pnpm build # build the server
-
-and
-
-pnpm start # start the server
-```
-
-The server will listen on the port defined in `PORT` (default: 8888).
 
 ## 📁 Project Structure
 
@@ -89,10 +94,6 @@ http-proxy/
     └── pt-br/
         └── README.md       # Documentation in Brazilian Portuguese
 ```
-
-## 📚 Documentation in Portuguese
-
-The complete documentation in Brazilian Portuguese is available at [`/docs/pt-br/README.md`](docs/pt-br/README.md).
 
 ## 🤝 Contributing
 

--- a/docs/pt-br/README.md
+++ b/docs/pt-br/README.md
@@ -1,7 +1,13 @@
 <h1 align="center"> 🧭 HTTP Proxy Server </h1>
 
 <p align="center">
-  <img src="./docs/static/demo.gif">
+  <img src="../static/demo.gif">
+</p>
+
+<p align="center">
+  <a href="../../../README.md">English</a>
+  | 
+  Português
 </p>
 
 Um servidor proxy HTTP robusto e configurável, desenvolvido em TypeScript, com autenticação, controle de acesso por host e registro de logs. Ideal para cenários como bots do Discord, raspagem de dados e controle de tráfego.

--- a/docs/pt-br/README.md
+++ b/docs/pt-br/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <a href="../../../README.md">English</a>
+  <a href="../../README.md">English</a>
   | 
   Português
 </p>


### PR DESCRIPTION
This pull request introduces a license file, improves multilingual support, and refines the documentation structure for the HTTP Proxy Server project. The most important changes include adding an MIT license, enhancing the README with multilingual links and usage instructions, and updating the Brazilian Portuguese documentation for consistency.

### Licensing:
* Added an `MIT License` file to the project, granting permission for free use, modification, and distribution under specified conditions. (`LICENSE`)

### Documentation Improvements:
* Updated `README.md` to include a link to Brazilian Portuguese documentation and added a new "Usage" section with instructions on building and running the proxy server. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R7-R12) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R47-R59)
* Removed redundant "Documentation in Portuguese" section in `README.md` to streamline content. (`README.md`)

### Multilingual Support:
* Enhanced the Brazilian Portuguese documentation (`docs/pt-br/README.md`) by adding a link to the English version and correcting the image path for consistency. (`docs/pt-br/README.md`)