### PR TITLE
Refactor / allowed hosts configuration to .env and update in docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,4 @@ ENABLE_LOGS=true
 ENABLE_ERROR_LOGS=true
 PROXY_USERNAME=proxyuser
 PROXY_PASSWORD=proxypass
-ALLOWED_HOSTS=[
-  'google.com',
-]
+ALLOWED_HOSTS='google.com','youtube.com'

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A robust and configurable HTTP proxy server developed in TypeScript, featuring a
    ENABLE_ERROR_LOGS=false
    PROXY_USERNAME=your_username
    PROXY_PASSWORD=your_password
+   ALLOWED_HOSTS='google.com','youtube.com'
    ```
 ## 🛠️ Usage
 

--- a/docs/pt-br/README.md
+++ b/docs/pt-br/README.md
@@ -43,6 +43,7 @@ Um servidor proxy HTTP robusto e configurável, desenvolvido em TypeScript, com 
    ENABLE_ERROR_LOGS=false
    PROXY_USERNAME=seu_usuario
    PROXY_PASSWORD=sua_senha
+   ALLOWED_HOSTS='google.com','youtube.com'
    ```
 
 ## 🛡️ Hosts Permitidos

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -10,7 +10,7 @@ const allowedHosts = (process.env.ALLOWED_HOSTS || '')
 const getHostFromRawHeaders = (rawHeaders: string[] = []): string | null => {
   for (let i = 0; i < rawHeaders.length; i += 2) {
     if (rawHeaders[i].toLowerCase() === 'host') {
-      return rawHeaders[i + 1];
+      return rawHeaders[i + 1].toLowerCase();
     }
   }
   return null;
@@ -68,7 +68,6 @@ export const startServer = async () => {
         }
 
         logger.info(`[PROXY] Client ${clientIp} ➔ Destination Host ${host}`);
-
         return {};
       } catch (err) {
         logger.error(`[PROXY] Error while processing the request: ${(err as Error).message}`);


### PR DESCRIPTION
This pull request includes updates to the handling of allowed hosts, documentation improvements, and minor code adjustments for consistency. The most important changes include modifying the `ALLOWED_HOSTS` environment variable format, updating documentation to reflect the new format, and improving the server code for better reliability and readability.

### Updates to allowed hosts configuration:
* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL6-R6): Changed the `ALLOWED_HOSTS` environment variable from a JSON-like array to a comma-separated string format (`'google.com','youtube.com'`).
* [`src/core/server.ts`](diffhunk://#diff-649ee31d2432d43c80f01b67d8c1257bfe45ca9e409444997f7e86a6425662bbL13-R13): Updated the `getHostFromRawHeaders` function to return the host in lowercase to ensure case-insensitive matching.

### Documentation improvements:
* `README.md` and `docs/pt-br/README.md`: Updated examples of the `ALLOWED_HOSTS` environment variable to use the new comma-separated string format. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R46) [[2]](diffhunk://#diff-3196ef0563b3833e8d2478ebb6a3f84febef5ef0364d8ea7b348c6168163b5b4R46)

### Code readability and logging:
* [`src/core/server.ts`](diffhunk://#diff-649ee31d2432d43c80f01b67d8c1257bfe45ca9e409444997f7e86a6425662bbL71): Removed an unnecessary blank line in the `startServer` function for improved code readability.