### PR TITLE
Docs / LINUX Service example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ pnpm start # start the server
 
 The server will listen on the port defined in `PORT` (default: 8888).
 
+## 🖥️ Running as a Linux Service
+
+See how to create a systemd service to run the proxy automatically on Linux in [`docs/linux-service.md`](./docs/linux-service.md).
+
 ## 📁 Project Structure
 
 ```

--- a/docs/LINUX-SERVICE.md
+++ b/docs/LINUX-SERVICE.md
@@ -1,0 +1,85 @@
+# 🖥️ Running the Proxy as a Service on Linux (systemd)
+
+This guide shows how to configure the HTTP Proxy to run automatically as a service on Linux using `systemd`.
+
+---
+
+## 1. Create the service file
+
+Create a file named `proxy.service` in `/etc/systemd/system/`:
+
+```ini
+[Unit]
+Description=HTTP Proxy Server (Node.js)
+After=network.target
+
+[Service]
+User=exampleuser
+WorkingDirectory=/path/to/http-proxy
+EnvironmentFile=/path/to/file/.env
+ExecStart=path/to/bin/node /path/to/http-proxy/dist/index.js
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+
+> **Note:**  
+> - Adjust the paths according to your environment (user, project directory, Node.js version).
+> - The `EnvironmentFile` line ensures that variables from `.env` are loaded.
+
+---
+
+## 2. Enable and start the service
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable proxy.service
+sudo systemctl start proxy.service
+```
+
+---
+
+## 3. Real-time logs
+
+With the `StandardOutput=journal` and `StandardError=journal` options, view real-time logs with:
+
+```bash
+sudo journalctl -u proxy.service -f
+```
+
+---
+
+## 4. Automatic restart via cron
+
+To ensure the service restarts every 2 hours, add this line to the root user's crontab:
+
+```cron
+0 */2 * * * /bin/systemctl restart proxy.service
+```
+
+Edit the root crontab with:
+
+```bash
+sudo crontab -e
+```
+
+---
+
+## 5. Tips
+
+- To check the service status:
+  ```bash
+  sudo systemctl status proxy.service
+  ```
+- To restart manually:
+  ```bash
+  sudo systemctl restart proxy.service
+  ```
+
+---
+
+Done! Your proxy will now run automatically as a service on Linux.

--- a/docs/pt-br/LINUX-SERVICE.md
+++ b/docs/pt-br/LINUX-SERVICE.md
@@ -1,0 +1,85 @@
+# 🖥️ Rodando o Proxy como Serviço no Linux (systemd)
+
+Este guia mostra como configurar o HTTP Proxy para rodar automaticamente como um serviço no Linux usando o `systemd`.
+
+---
+
+## 1. Crie o arquivo de serviço
+
+Crie um arquivo chamado `proxy.service` em `/etc/systemd/system/`:
+
+```ini
+[Unit]
+Description=HTTP Proxy Server (Node.js)
+After=network.target
+
+[Service]
+User=dino
+WorkingDirectory=/path/to/http-proxy
+EnvironmentFile=/path/to/file/.env
+ExecStart=path/to/bin/node /path/to/http-proxy/dist/index.js
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+
+> **Atenção:**  
+> - Ajuste os caminhos de acordo com o seu ambiente (usuário, diretório do projeto, versão do Node.js).
+> - A linha `EnvironmentFile` garante que as variáveis do `.env` sejam carregadas.
+
+---
+
+## 2. Habilite e inicie o serviço
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable proxy.service
+sudo systemctl start proxy.service
+```
+
+---
+
+## 3. Logs em tempo real
+
+Com as opções `StandardOutput=journal` e `StandardError=journal`, visualize os logs em tempo real com:
+
+```bash
+sudo journalctl -u proxy.service -f
+```
+
+---
+
+## 4. Reinício automático via cron
+
+Para garantir que o serviço seja reiniciado a cada 2 horas, adicione esta linha ao crontab do root:
+
+```cron
+0 */2 * * * /bin/systemctl restart proxy.service
+```
+
+Edite o crontab do root com:
+
+```bash
+sudo crontab -e
+```
+
+---
+
+## 5. Dicas
+
+- Para verificar o status do serviço:
+  ```bash
+  sudo systemctl status proxy.service
+  ```
+- Para reiniciar manualmente:
+  ```bash
+  sudo systemctl restart proxy.service
+  ```
+
+---
+
+Pronto! Agora seu proxy será executado automaticamente como serviço no Linux.

--- a/docs/pt-br/README.md
+++ b/docs/pt-br/README.md
@@ -60,6 +60,10 @@ pnpm start # inicia o servidor
 
 O servidor irá escutar na porta definida em `PORT` (padrão: 8888).
 
+## 🖥️ Rodando como serviço no Linux
+
+Veja como criar um serviço systemd para rodar o proxy automaticamente no Linux em [`docs/linux-service.md`](./docs/linux-service.md).
+
 ## 📁 Estrutura do Projeto
 
 ```

--- a/docs/pt-br/README.md
+++ b/docs/pt-br/README.md
@@ -62,8 +62,7 @@ O servidor irá escutar na porta definida em `PORT` (padrão: 8888).
 
 ## 🖥️ Rodando como serviço no Linux
 
-Veja como criar um serviço systemd para rodar o proxy automaticamente no Linux em [`docs/linux-service.md`](./docs/linux-service.md).
-
+Veja como criar um serviço systemd para rodar o proxy automaticamente no Linux em [`LINUX-SERVICE.md`](./LINUX-SERVICE.md).
 ## 📁 Estrutura do Projeto
 
 ```


### PR DESCRIPTION
This pull request introduces documentation updates to guide users on running the HTTP Proxy as a Linux service using `systemd`. It includes detailed instructions in both English and Portuguese, along with references in the respective `README.md` files.

### Documentation for running as a Linux service:

* [`docs/LINUX-SERVICE.md`](diffhunk://#diff-6148b435cf13e032a239d2801260d5a9d9bedf43022df5e9163a7fcc52f9c89bR1-R85): Added a comprehensive guide on configuring the HTTP Proxy to run as a `systemd` service on Linux. The guide includes steps for creating the service file, enabling and starting the service, viewing real-time logs, setting up automatic restarts via `cron`, and additional tips.

* [`docs/pt-br/LINUX-SERVICE.md`](diffhunk://#diff-b539f7547d669616c6bc4522108ed557d10fe4bc0754b9cccc2b39ddd89b0811R1-R85): Added the same guide as above, translated into Portuguese, with localized examples and instructions.

### References in README files:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62-R65): Added a section linking to the new guide on running the proxy as a Linux service.

* [`docs/pt-br/README.md`](diffhunk://#diff-3196ef0563b3833e8d2478ebb6a3f84febef5ef0364d8ea7b348c6168163b5b4R63-R66): Added a similar section in the Portuguese `README.md`, linking to the translated guide.